### PR TITLE
Fix annotation service connection

### DIFF
--- a/dashboard/TROUBLESHOOTING.md
+++ b/dashboard/TROUBLESHOOTING.md
@@ -1,0 +1,137 @@
+# Annotation Service Troubleshooting Guide
+
+## Issue: `/annotation/` returns 404
+
+This document outlines the fixes applied to resolve the broken connection to `tools/annotation` service.
+
+## Root Causes Identified
+
+1. **Nginx Configuration Issues**: Missing `X-Script-Name` headers and inconsistent upstream references
+2. **Error Handling**: Poor error reporting made debugging difficult
+3. **Health Checks**: No easy way to verify service connectivity
+
+## Fixes Applied
+
+### 1. Enhanced Nginx Configuration (`nginx-compose.conf`)
+
+- **Added `X-Script-Name` headers** to all proxy locations for proper Flask URL generation
+- **Improved error handling** with fallback locations and better error messages
+- **Added debug headers** to help troubleshoot routing issues
+- **Added annotation health check** endpoint at `/annotation/health`
+
+### 2. Better Error Reporting
+
+```nginx
+# Fallback location for annotation service errors
+location @annotation_fallback {
+    add_header Content-Type text/plain;
+    return 503 "Annotation service temporarily unavailable. Please check that the annotation-app container is running.";
+}
+```
+
+### 3. Debug Tools Created
+
+- **`test_annotation.py`**: Python script to test service connectivity
+- **`docker-compose.debug.yml`**: Debug configuration with enhanced logging
+- **`start_debug.sh`**: Automated startup and testing script
+
+## Testing the Fix
+
+### Quick Test
+```bash
+# Start services
+cd /workspace/dashboard
+./start_debug.sh
+
+# Or manually:
+docker compose up -d
+python3 test_annotation.py localhost
+```
+
+### Manual Verification
+1. **Dashboard**: http://localhost:8080 → Should show dashboard
+2. **Annotation Tool**: http://localhost:8080/annotation/ → Should show annotation interface
+3. **Health Check**: http://localhost:8080/annotation/health → Should return session data
+4. **Direct Flask**: http://localhost:5000 → Should work if annotation-app is running
+
+## Common Issues and Solutions
+
+### 1. Service Not Starting
+```bash
+# Check container status
+docker compose ps
+
+# Check logs
+docker compose logs annotation-app
+docker compose logs nginx
+```
+
+### 2. Network Connectivity Issues
+```bash
+# Test internal network
+docker compose exec nginx ping annotation-app
+
+# Check port bindings
+docker compose port nginx 80
+docker compose port annotation-app 5000
+```
+
+### 3. Static Files Not Loading
+- Verify nginx proxy configuration for `/annotation/static/`
+- Check Flask `static_url_path` configuration in `app.py`
+- Ensure static files exist in `tools/annotation/static/`
+
+### 4. API Endpoints Failing
+- Check that API routes are properly registered in Flask
+- Verify nginx proxy rules for `/annotation/api/` paths
+- Test direct Flask API access: http://localhost:5000/api/sessions
+
+## Configuration Summary
+
+### Docker Compose Services
+- **annotation-app**: Flask service on port 5000 (internal network)
+- **nginx**: Reverse proxy on port 8080 (external access)
+
+### Nginx Routing
+- `/` → Dashboard static files
+- `/annotation/` → Flask app root (`annotation-app:5000/`)
+- `/annotation/api/` → Flask API (`annotation-app:5000/api/`)
+- `/annotation/static/` → Flask static files
+- `/health` → Nginx health check
+- `/annotation/health` → Flask app health check
+
+### Flask Configuration
+- **Application Root**: `/annotation` (for reverse proxy)
+- **Static URL Path**: `/annotation/static`
+- **Routes**: `/` and `/annotation/` both serve the main interface
+
+## Debugging Commands
+
+```bash
+# View nginx access logs
+docker compose exec nginx tail -f /var/log/nginx/access.log
+
+# View nginx error logs
+docker compose exec nginx tail -f /var/log/nginx/error.log
+
+# Test nginx configuration
+docker compose exec nginx nginx -t
+
+# Restart services
+docker compose restart
+
+# View Flask logs
+docker compose logs -f annotation-app
+```
+
+## Next Steps
+
+If the issue persists after applying these fixes:
+
+1. Check Docker network connectivity
+2. Verify that both services are healthy
+3. Test direct Flask access on port 5000
+4. Review nginx and Flask logs for specific errors
+5. Use the provided test script to identify the failing component
+
+The configuration should now properly route requests from `/annotation/` to the Flask application while maintaining proper static file serving and API functionality.

--- a/dashboard/docker-compose.debug.yml
+++ b/dashboard/docker-compose.debug.yml
@@ -1,0 +1,17 @@
+version: '3.8'
+
+services:
+  annotation-app:
+    environment:
+      - FLASK_ENV=development
+      - FLASK_DEBUG=1
+      - FLASK_HOST=0.0.0.0
+      - FLASK_PORT=5000
+    command: ["python", "app.py", "--host", "0.0.0.0", "--port", "5000", "--debug"]
+    
+  nginx:
+    volumes:
+      - ./nginx-compose.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./static:/usr/share/nginx/html:ro
+      # Mount nginx logs for debugging
+      - ./logs:/var/log/nginx:rw

--- a/dashboard/nginx-compose.conf
+++ b/dashboard/nginx-compose.conf
@@ -6,13 +6,14 @@ server {
     access_log /var/log/nginx/access.log;
     error_log /var/log/nginx/error.log debug;
 
-    # Image endpoint (prefixed) - handle query-string form like /annotation/api/image?...
+    # API endpoints for annotation tool - specific routes first
     location /annotation/api/frame {
         proxy_pass http://annotation-app:5000/api/frame$is_args$args;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Script-Name /annotation;
         proxy_http_version 1.1;
         
         # Enable buffering for binary content
@@ -27,18 +28,20 @@ server {
         proxy_read_timeout 60s;
     }
 
-    # Other API endpoints for annotation tool - MUST come FIRST
+    # Other API endpoints for annotation tool
     location ~ ^/annotation/api/(.*)$ {
         proxy_pass http://annotation-app:5000/api/$1$is_args$args;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Script-Name /annotation;
         proxy_http_version 1.1;
         proxy_buffering off;
 
-        # Debug (optional)
+        # Debug headers
         add_header X-Debug-Args $args always;
+        add_header X-Debug-Upstream "annotation-app:5000" always;
     }
 
     # Serve static dashboard files
@@ -80,8 +83,22 @@ server {
         add_header Pragma "no-cache" always;
         add_header Expires "0" always;
         
+        # Debug headers for troubleshooting
+        add_header X-Debug-Upstream "annotation-app:5000" always;
+        add_header X-Debug-Script-Name "/annotation" always;
+        
         # Rewrite location headers to fix static file paths
         proxy_redirect ~^http://[^/]+/(.*) /annotation/$1;
+        
+        # Better error handling
+        proxy_intercept_errors on;
+        error_page 502 503 504 @annotation_fallback;
+    }
+    
+    # Fallback location for annotation service errors
+    location @annotation_fallback {
+        add_header Content-Type text/plain;
+        return 503 "Annotation service temporarily unavailable. Please check that the annotation-app container is running.";
     }
 
     
@@ -93,11 +110,27 @@ server {
         add_header Cache-Control "public, immutable";
     }
 
-    # Health check endpoint
+    # Health check endpoint for nginx
     location /health {
         access_log off;
         return 200 "nginx healthy\n";
         add_header Content-Type text/plain;
+    }
+    
+    # Health check endpoint for annotation service
+    location /annotation/health {
+        proxy_pass http://annotation-app:5000/api/sessions;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_http_version 1.1;
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 10s;
+        proxy_read_timeout 10s;
+        
+        # Add debug info
+        add_header X-Debug-Health-Check "annotation-app:5000/api/sessions" always;
     }
 
     # Error pages

--- a/dashboard/start_debug.sh
+++ b/dashboard/start_debug.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -e
+
+echo "Starting Dashboard with Debug Configuration"
+echo "=========================================="
+
+# Create logs directory
+mkdir -p logs
+
+# Stop any existing containers
+echo "Stopping existing containers..."
+docker compose down 2>/dev/null || true
+
+# Start services with debug configuration
+echo "Starting services with debug logging..."
+docker compose -f docker-compose.yml -f docker-compose.debug.yml up -d
+
+# Wait for services to start
+echo "Waiting for services to start..."
+sleep 10
+
+# Check service status
+echo -e "\nService Status:"
+echo "==============="
+docker compose ps
+
+# Check container logs
+echo -e "\nAnnotation App Logs (last 20 lines):"
+echo "===================================="
+docker compose logs --tail=20 annotation-app
+
+echo -e "\nNginx Logs (last 20 lines):"
+echo "============================"
+docker compose logs --tail=20 nginx
+
+# Test connectivity
+echo -e "\nTesting connectivity..."
+echo "======================="
+python3 test_annotation.py localhost 2>/dev/null || echo "Test script failed - install requests: pip3 install requests"
+
+echo -e "\nDebug complete! Services are running at:"
+echo "- Dashboard: http://localhost:8080"
+echo "- Annotation: http://localhost:8080/annotation/"
+echo "- Direct Flask: http://localhost:5000"
+echo ""
+echo "To view live logs: docker compose logs -f"
+echo "To stop services: docker compose down"


### PR DESCRIPTION
Fix 404 for `/annotation/` by adding `X-Script-Name` header to nginx and improving debugging tools.

The Flask application, when served behind an Nginx reverse proxy, requires the `X-Script-Name` header to correctly generate URLs. This PR adds this crucial header to the Nginx configuration, along with new health check endpoints, improved error handling, and debugging scripts to resolve the 404 issue and facilitate future troubleshooting for the annotation service.

---
<a href="https://cursor.com/background-agent?bcId=bc-38797e49-7479-410d-9c1e-ba6a8d1343a4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-38797e49-7479-410d-9c1e-ba6a8d1343a4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

