### PR TITLE
Refine research screen page classification

### DIFF
--- a/research/screen-page-classification/distillation_pipeline.py
+++ b/research/screen-page-classification/distillation_pipeline.py
@@ -475,9 +475,17 @@ class DistillationPipeline:
     
     def _save_best_student_model(self):
         """Save the best student model."""
-        # This would save to a specific path
-        # Implementation depends on your file structure
-        pass
+        # Derive output directory similar to trainer
+        base_dir = Path(self.data_config.experiments_output_dir or (Path(self.data_config.output_dir) / "experiments"))
+        exp_dir = base_dir / "distillation"
+        exp_dir.mkdir(parents=True, exist_ok=True)
+
+        save_path = exp_dir / "best_student_model.pth"
+        torch.save({
+            'model_state_dict': self.student_model.state_dict(),
+            'model_info': get_model_info(self.student_model)
+        }, save_path)
+        console.print(f"[green]Saved best student model to {save_path}[/green]")
     
     def compare_models(
         self,

--- a/research/screen-page-classification/requirements.txt
+++ b/research/screen-page-classification/requirements.txt
@@ -16,8 +16,8 @@ opencv-python>=4.8.0
 albumentations>=1.3.0
 wandb>=0.15.0
 tensorboard>=2.13.0
-sqlite3
 flask>=2.3.0
 requests>=2.31.0
 tqdm>=4.65.0
 rich>=13.0.0
+PyYAML>=6.0.0

--- a/research/screen-page-classification/trainer.py
+++ b/research/screen-page-classification/trainer.py
@@ -143,8 +143,9 @@ class ClassificationTrainer:
         self.use_wandb = use_wandb
         self.use_tensorboard = use_tensorboard
         
-        # Setup directories
-        self.output_dir = Path(config.output_dir) / "experiments" / experiment_name
+        # Setup directories (prefer experiments.output_dir from config.yaml if provided)
+        base_experiments_dir = config.experiments_output_dir or (Path(config.output_dir) / "experiments")
+        self.output_dir = Path(base_experiments_dir) / experiment_name
         self.output_dir.mkdir(parents=True, exist_ok=True)
         
         # Setup logging


### PR DESCRIPTION
Refine the `screen-page-classification` research pipeline by improving config loading, output pathing, and model saving for smoother operation.

---
<a href="https://cursor.com/background-agent?bcId=bc-c42c507d-c3ee-4032-84c5-20c089488395">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c42c507d-c3ee-4032-84c5-20c089488395">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

